### PR TITLE
Add ability to specify Master/Slave and auto fetch-backups if slave

### DIFF
--- a/setup-wale.sh
+++ b/setup-wale.sh
@@ -16,19 +16,43 @@ else
             umask u=rwx,g=rx,o=
             mkdir -p /etc/wal-e.d/env
 
-            echo "$AWS_SECRET_ACCESS_KEY" > /etc/wal-e.d/env/AWS_SECRET_ACCESS_KEY
             echo "$AWS_ACCESS_KEY_ID" > /etc/wal-e.d/env/AWS_ACCESS_KEY_ID
+            echo "$AWS_SECRET_ACCESS_KEY" > /etc/wal-e.d/env/AWS_SECRET_ACCESS_KEY
             echo "$WALE_S3_PREFIX" > /etc/wal-e.d/env/WALE_S3_PREFIX
             chown -R root:postgres /etc/wal-e.d
 
-            # wal-e specific
-            echo "wal_level = archive" >> /var/lib/postgresql/data/postgresql.conf
-            echo "archive_mode = on" >> /var/lib/postgresql/data/postgresql.conf
-            echo "archive_command = 'envdir /etc/wal-e.d/env /usr/local/bin/wal-e wal-push %p'" >> /var/lib/postgresql/data/postgresql.conf
-            echo "archive_timeout = 60" >> /var/lib/postgresql/data/postgresql.conf
+            if [ "$POSTGRES_AUTHORITY" = "slave" ]
+            then
+                echo "Authority: Slave - Fetching latest backups";
 
-            su - postgres -c "crontab -l | { cat; echo \"0 3 * * * /usr/bin/envdir /etc/wal-e.d/env /usr/local/bin/wal-e backup-push /var/lib/postgresql/data\"; } | crontab -"
-            su - postgres -c "crontab -l | { cat; echo \"0 4 * * * /usr/bin/envdir /etc/wal-e.d/env /usr/local/bin/wal-e delete --confirm retain 7\"; } | crontab -"
+                # $PGDATA cannot be removed so use temporary dir
+                # If you don't stop the server first, you'll waste 5hrs debugging why your WALs aren't pulled
+                su - postgres -c "envdir /etc/wal-e.d/env /usr/local/bin/wal-e backup-fetch /tmp/pg-data LATEST"
+                gosu postgres pg_ctl -D "$PGDATA" -w stop
+                su - postgres -c "cp -rf /tmp/pg-data/* $PGDATA"
+                su - postgres -c "rm -rf /tmp/pg-data"
+
+                # Create recovery.conf
+                echo "standby_mode     = 'yes'" >> $PGDATA/recovery.conf
+                echo "primary_conninfo = 'host=$POSTGRES_MASTER_HOST user=$POSTGRES_USER password=$POSTGRES_PASSWORD'" >> $PGDATA/recovery.conf
+                echo "restore_command  = 'envdir /etc/wal-e.d/env wal-e wal-fetch "%f" "%p"'" >> $PGDATA/recovery.conf
+                echo "trigger_file     = '$PGDATA/trigger'" >> $PGDATA/recovery.conf
+
+                chown -R postgres "$PGDATA"
+
+                # Starting server again to satisfy init script
+                gosu postgres pg_ctl -D "$PGDATA" -o "-c listen_addresses=''" -w start
+            else
+                echo "Authority: Master - Scheduling WAL backups";
+
+                echo "wal_level = archive" >> /var/lib/postgresql/data/postgresql.conf
+                echo "archive_mode = on" >> /var/lib/postgresql/data/postgresql.conf
+                echo "archive_command = 'envdir /etc/wal-e.d/env /usr/local/bin/wal-e wal-push %p'" >> /var/lib/postgresql/data/postgresql.conf
+                echo "archive_timeout = 60" >> /var/lib/postgresql/data/postgresql.conf
+
+                su - postgres -c "crontab -l | { cat; echo \"0 3 * * * /usr/bin/envdir /etc/wal-e.d/env /usr/local/bin/wal-e backup-push /var/lib/postgresql/data\"; } | crontab -"
+                su - postgres -c "crontab -l | { cat; echo \"0 4 * * * /usr/bin/envdir /etc/wal-e.d/env /usr/local/bin/wal-e delete --confirm retain 7\"; } | crontab -"
+            fi
         fi
     fi
 fi


### PR DESCRIPTION
Two new ENV vars:
- POSTGRES_AUTHORITY=slave
- POSTGRES_MASTER_HOST=1.2.3.4

If you pass in "slave" authority, the server will fetch the LATEST backup from AWS and recover the node to it's current state.

There were two headaches here for me: 
- You can't delete $PGDATA as it's in use, so you have to download to /tmp and copy it in
- You have to stop the server before copying in the files or else when the server comes back up again, it'll try and download incorrect WAL files and you'll end up with an empty DB (spent about 5hrs debugging this!). You have to bring the server back up again or else the original init script complains that postmaster.pid doesn't exist when it tries to stop it.
